### PR TITLE
feat: add only-audio-mode support

### DIFF
--- a/src/SipConnector.ts
+++ b/src/SipConnector.ts
@@ -953,7 +953,7 @@ export default class SipConnector {
   _generateStream(videoTrack: MediaStreamTrack, audioTrack?: MediaStreamTrack): MediaStream {
     const id = videoTrack.id;
 
-    const remoteStream = this._remoteStreams[id] || new MediaStream();
+    const remoteStream: MediaStream = this._remoteStreams[id] || new MediaStream();
 
     if (audioTrack) {
       remoteStream.addTrack(audioTrack);
@@ -1002,13 +1002,7 @@ export default class SipConnector {
   }
 
   _generateAudioStreams(remoteTracks: MediaStreamTrack[]): MediaStream[] {
-    const remoteStreams: MediaStream[] = [];
-
-    remoteTracks.forEach((audioTrack) => {
-      const remoteStream = this._generateAudioStream(audioTrack);
-
-      remoteStreams.push(remoteStream);
-    });
+    const remoteStreams: MediaStream[] = remoteTracks.map(this._generateAudioStream);
 
     return remoteStreams;
   }

--- a/src/SipConnector.ts
+++ b/src/SipConnector.ts
@@ -950,15 +950,8 @@ export default class SipConnector {
     });
   };
 
-  _generateStream(
-    videoTrack: MediaStreamTrack,
-    audioTrack?: MediaStreamTrack
-  ): MediaStream | undefined {
-    const id = videoTrack?.id;
-
-    if (!id) {
-      return undefined;
-    }
+  _generateStream(videoTrack: MediaStreamTrack, audioTrack?: MediaStreamTrack): MediaStream {
+    const id = videoTrack.id;
 
     const remoteStream = this._remoteStreams[id] || new MediaStream();
 
@@ -1002,9 +995,7 @@ export default class SipConnector {
 
       const remoteStream = this._generateStream(videoTrack, audioTrack);
 
-      if (remoteStream) {
-        remoteStreams.push(remoteStream);
-      }
+      remoteStreams.push(remoteStream);
     }, []);
 
     return remoteStreams;

--- a/src/__tests__/callWithNoVideoTracks.ts
+++ b/src/__tests__/callWithNoVideoTracks.ts
@@ -1,0 +1,58 @@
+import { createMediaStreamMock } from 'webrtc-mock';
+import createSipConnector from '../__mocks__/doMock';
+import { dataForConnectionWithAuthorization } from '../__mocks__';
+import type SipConnector from '../SipConnector';
+
+describe('call with no video tracks', () => {
+  let sipConnector: SipConnector;
+  let mediaStream;
+  let mockFn;
+
+  beforeEach(() => {
+    sipConnector = createSipConnector();
+    mediaStream = createMediaStreamMock({
+      audio: { deviceId: { exact: 'audioDeviceId' } },
+    });
+    mockFn = jest.fn(() => {
+      return undefined;
+    });
+  });
+
+  it('should exist peerconnection when call with no video tracks', async () => {
+    expect.assertions(1);
+
+    await sipConnector.connect(dataForConnectionWithAuthorization);
+
+    const number = `10000`;
+    const peerconnection = await sipConnector.call({ number, mediaStream, ontrack: mockFn });
+
+    expect(!!peerconnection).toBe(true);
+  });
+
+  it('isCallActive is true after call', async () => {
+    expect.assertions(2);
+
+    await sipConnector.connect(dataForConnectionWithAuthorization);
+
+    expect(sipConnector.isCallActive).toBe(false);
+
+    const number = `10000`;
+
+    await sipConnector.call({ number, mediaStream, ontrack: mockFn });
+
+    expect(sipConnector.isCallActive).toBe(true);
+  });
+
+  it('getRemoteStreams', async () => {
+    expect.assertions(1);
+
+    const number = `10000`;
+
+    await sipConnector.connect(dataForConnectionWithAuthorization);
+    await sipConnector.call({ number, mediaStream, ontrack: mockFn });
+
+    const remoteStreams = sipConnector.getRemoteStreams();
+
+    expect(remoteStreams!.length).toBe(1);
+  });
+});


### PR DESCRIPTION
Need to add audio-only mode support for call without video tracks in mediastream.