### PR TITLE
fix(sip-connector): set correct context for generate audio stream method

### DIFF
--- a/src/SipConnector.ts
+++ b/src/SipConnector.ts
@@ -1002,7 +1002,9 @@ export default class SipConnector {
   }
 
   _generateAudioStreams(remoteTracks: MediaStreamTrack[]): MediaStream[] {
-    const remoteStreams: MediaStream[] = remoteTracks.map(this._generateAudioStream);
+    const remoteStreams: MediaStream[] = remoteTracks.map((remoteTrack) => {
+      return this._generateAudioStream(remoteTrack); 
+    });
 
     return remoteStreams;
   }

--- a/src/__mocks__/Session.mock.ts
+++ b/src/__mocks__/Session.mock.ts
@@ -52,14 +52,26 @@ class Session extends BaseSession {
     return true;
   }
 
+  hasVideoTracks(mediaStream: MediaStream): boolean {
+    return !!mediaStream.getVideoTracks().length;
+  }
+
   createPeerconnection(sendedStream: any) {
     const audioTrack = createAudioMediaStreamTrackMock();
-    const videoTrack = createVideoMediaStreamTrackMock();
-
     audioTrack.id = 'mainaudio1';
-    videoTrack.id = 'mainvideo1';
 
-    this._connection = new RTCPeerConnectionMock([audioTrack, videoTrack]);
+    const tracks = [audioTrack];
+
+    const isVideoStream = this.hasVideoTracks(sendedStream);
+
+    if (isVideoStream) {
+      const videoTrack = createVideoMediaStreamTrackMock();
+      videoTrack.id = 'mainvideo1';
+
+      tracks.push(videoTrack);
+    }
+
+    this._connection = new RTCPeerConnectionMock(tracks);
 
     this._addStream(sendedStream);
 

--- a/src/__mocks__/Session.mock.ts
+++ b/src/__mocks__/Session.mock.ts
@@ -7,6 +7,10 @@ const CONNECTION_DELAY = 400; // more 300 for test cancel requests with debounce
 
 export const FAILED_CONFERENCE_NUMBER = '777';
 
+const hasVideoTracks = (mediaStream: MediaStream): boolean => {
+  return !!mediaStream.getVideoTracks().length;
+}
+
 /* eslint-disable class-methods-use-this */
 
 class Session extends BaseSession {
@@ -52,17 +56,13 @@ class Session extends BaseSession {
     return true;
   }
 
-  hasVideoTracks(mediaStream: MediaStream): boolean {
-    return !!mediaStream.getVideoTracks().length;
-  }
-
   createPeerconnection(sendedStream: any) {
     const audioTrack = createAudioMediaStreamTrackMock();
     audioTrack.id = 'mainaudio1';
 
     const tracks = [audioTrack];
 
-    const isVideoStream = this.hasVideoTracks(sendedStream);
+    const isVideoStream = hasVideoTracks(sendedStream);
 
     if (isVideoStream) {
       const videoTrack = createVideoMediaStreamTrackMock();

--- a/src/__tests__/callWithNoVideoTracks.ts
+++ b/src/__tests__/callWithNoVideoTracks.ts
@@ -60,9 +60,8 @@ describe('call with no video tracks', () => {
     await sipConnector.call({ number, mediaStream, ontrack: mockFn });
 
     const remoteStreams = sipConnector.getRemoteStreams();
-
-    // @ts-ignore
-    const videoTrack = remoteStreams[0].getVideoTracks();
+    
+    const videoTrack = remoteStreams![0].getVideoTracks();
 
     expect(videoTrack.length).toBe(0);
   });

--- a/src/__tests__/callWithNoVideoTracks.ts
+++ b/src/__tests__/callWithNoVideoTracks.ts
@@ -3,6 +3,8 @@ import createSipConnector from '../__mocks__/doMock';
 import { dataForConnectionWithAuthorization } from '../__mocks__';
 import type SipConnector from '../SipConnector';
 
+const number = `10000`;
+
 describe('call with no video tracks', () => {
   let sipConnector: SipConnector;
   let mediaStream;
@@ -23,7 +25,6 @@ describe('call with no video tracks', () => {
 
     await sipConnector.connect(dataForConnectionWithAuthorization);
 
-    const number = `10000`;
     const peerconnection = await sipConnector.call({ number, mediaStream, ontrack: mockFn });
 
     expect(!!peerconnection).toBe(true);
@@ -36,8 +37,6 @@ describe('call with no video tracks', () => {
 
     expect(sipConnector.isCallActive).toBe(false);
 
-    const number = `10000`;
-
     await sipConnector.call({ number, mediaStream, ontrack: mockFn });
 
     expect(sipConnector.isCallActive).toBe(true);
@@ -46,13 +45,25 @@ describe('call with no video tracks', () => {
   it('getRemoteStreams', async () => {
     expect.assertions(1);
 
-    const number = `10000`;
-
     await sipConnector.connect(dataForConnectionWithAuthorization);
     await sipConnector.call({ number, mediaStream, ontrack: mockFn });
 
     const remoteStreams = sipConnector.getRemoteStreams();
 
     expect(remoteStreams!.length).toBe(1);
+  });
+
+  it('should no exist video tracks in incoming mediaStream when call with no video', async () => {
+    expect.assertions(1);
+
+    await sipConnector.connect(dataForConnectionWithAuthorization);
+    await sipConnector.call({ number, mediaStream, ontrack: mockFn });
+
+    const remoteStreams = sipConnector.getRemoteStreams();
+
+    // @ts-ignore
+    const videoTrack = remoteStreams[0].getVideoTracks();
+
+    expect(videoTrack.length).toBe(0);
   });
 });


### PR DESCRIPTION
Set correct context for generate audio stream method + fix for session.mock (create peerconnection with audio stream when incoming mediaStream has no video tracks