### PR TITLE
fix: enterRoom data format changed

### DIFF
--- a/src/__fixtures__/utils.ts
+++ b/src/__fixtures__/utils.ts
@@ -1,5 +1,5 @@
 export function getRoomFromSipUrl(sipUrl: string): string {
-  const matches = sipUrl.match(/[\d.]+/g);
+  const matches = sipUrl.match(/(purgatory)|[\d.]+/g);
 
   if (!matches) {
     throw new Error('wrong sip url');

--- a/src/tools/__fixtures__/call.ts
+++ b/src/tools/__fixtures__/call.ts
@@ -5,7 +5,14 @@ import {
 } from 'webrtc-mock';
 import RTCPeerConnectionMock from '../../__fixtures__/RTCPeerConnectionMock';
 
+const PURGATORY_NUMBER = 'purgatory';
+
+export const onEnterPurgatory = jest.fn();
+export const onEnterConference = jest.fn();
+
 const data = {
+  onEnterPurgatory,
+  onEnterConference,
   mediaStream: createMediaStreamMock({
     video: {
       deviceId: {
@@ -24,6 +31,13 @@ const data = {
 };
 
 export default data;
+
+export const dataCallPurgatory = {
+  ...data,
+  onEnterPurgatory,
+  onEnterConference,
+  conference: PURGATORY_NUMBER,
+};
 
 const audioTrack = createAudioMediaStreamTrackMock();
 const videoTrack = createVideoMediaStreamTrackMock();

--- a/src/tools/__tests__/callToServer.ts
+++ b/src/tools/__tests__/callToServer.ts
@@ -1,5 +1,10 @@
 import doMockSIPconnector from '../../doMock';
-import dataCall, { peerConnectionFromData } from '../__fixtures__/call';
+import dataCall, {
+  peerConnectionFromData,
+  dataCallPurgatory,
+  onEnterPurgatory,
+  onEnterConference,
+} from '../__fixtures__/call';
 import { dataForConnectionWithoutAuthorization } from '../__fixtures__/connectToServer';
 import parseObject from '../__tests-utils__/parseObject';
 import resolveCall from '../callToServer';
@@ -18,7 +23,7 @@ describe('callToServer', () => {
   });
 
   it('check call', async () => {
-    expect.assertions(1);
+    expect.assertions(3);
 
     return connectToServer(dataForConnectionWithoutAuthorization)
       .then(async () => {
@@ -29,6 +34,21 @@ describe('callToServer', () => {
         expect(parseObject(peerConnection._receivers)).toEqual(
           parseObject(peerConnectionFromData._receivers),
         );
+        expect(onEnterPurgatory).toHaveBeenCalledTimes(0);
+        expect(onEnterConference).toHaveBeenCalledTimes(1);
+      });
+  });
+
+  it('chould call correct handler after purgatory call', async () => {
+    expect.assertions(2);
+
+    return connectToServer(dataForConnectionWithoutAuthorization)
+      .then(async () => {
+        return call(dataCallPurgatory);
+      })
+      .then(() => {
+        expect(onEnterPurgatory).toHaveBeenCalledTimes(1);
+        expect(onEnterConference).toHaveBeenCalledTimes(0);
       });
   });
 });

--- a/src/tools/callToServer.ts
+++ b/src/tools/callToServer.ts
@@ -65,7 +65,7 @@ const resolveCallToServer = (sipConnector: SipConnector) => {
       log('subscribeEnterConference: onEnterConference', onEnterConference);
 
       if (onEnterPurgatory ?? onEnterConference) {
-        return sipConnector.onSession('enterRoom', (_room: string) => {
+        return sipConnector.onSession('enterRoom', ({ room: _room }: { room: string }) => {
           log('enterRoom', { _room, isSuccessProgressCall });
 
           room = _room;


### PR DESCRIPTION
event 'enterRoom' now provides data in object format `{room: string}`. Previously it was jest a string: `room: string`